### PR TITLE
hide data field if empty when confirming txs

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -77,6 +77,7 @@ typedef enum {
 #define SHA3_KECCAK_BITS      256
 #define PUBLIC_KEY_LEN        32
 #define BASE_10               10
+#define TX_SIGN_FLOW_SIZE     8
 #define BASE_64_INVALID_CHAR     '?'
 #define SC_ARGS_SEPARATOR        '@'
 #define MAX_ESDT_VALUE_HEX_COUNT 32

--- a/src/sign_tx_hash.c
+++ b/src/sign_tx_hash.c
@@ -15,7 +15,7 @@ bool sign_tx_hash(uint8_t *data_buffer);
 bool is_esdt_transfer();
 void display_tx_sign_flow();
 
-const ux_flow_step_t *tx_flow[8];
+const ux_flow_step_t *tx_flow[TX_SIGN_FLOW_SIZE];
 
 // UI for confirming the ESDT transfer on screen
 UX_STEP_NOCB(


### PR DESCRIPTION
When confirming a transaction, the flow won't display the `Data` field if it is 0 length