### PR TITLE
fix compilation warnings

### DIFF
--- a/src/sign_msg.c
+++ b/src/sign_msg.c
@@ -150,11 +150,7 @@ void handle_sign_msg(uint8_t p1,
 
     // finalize hash, compute it and store it in `msg_context.strhash` for display
     cx_hash((cx_hash_t *) &sha3_context, CX_LAST, data_buffer, 0, msg_context.hash, HASH_LEN);
-    snprintf(msg_context.strhash,
-             sizeof(msg_context.strhash),
-             "%.*H",
-             sizeof(msg_context.hash),
-             msg_context.hash);
+    convert_to_hex_str(msg_context.strhash, msg_context.hash, sizeof(msg_context.hash));
 
     // sign the hash
     if (!sign_message()) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,3 +33,12 @@ void uint32_t_to_char_array(uint32_t const input, char *output) {
     }
     output[pos] = '\0';
 }
+
+void convert_to_hex_str(char* str, uint8_t* val, size_t val_count) {
+    static char hex[] = "0123456789ABCDEF";
+	for (size_t i = 0; i < val_count; i++)
+	{
+		str[(i * 2) + 0] = hex[((val[i] & 0xF0) >> 4)];
+		str[(i * 2) + 1] = hex[((val[i] & 0x0F) >> 0)];
+	}
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,4 +11,6 @@ void send_response(uint8_t tx, bool approve);
 
 void uint32_t_to_char_array(uint32_t const input, char *output);
 
+void convert_to_hex_str(char* str, uint8_t* val, size_t val_count);
+
 #endif


### PR DESCRIPTION
fix compilation warnings by using a separate function for printing hex characters